### PR TITLE
Fixed severals bugs

### DIFF
--- a/src/DspObject.cpp
+++ b/src/DspObject.cpp
@@ -71,6 +71,8 @@ DspObject::~DspObject() {
 #pragma mark -
 
 ConnectionType DspObject::getConnectionType(int outletIndex) {
+  if (outletIndex >= getNumDspOutlets())
+    return MESSAGE;
   return DSP;
 }
 

--- a/src/DspObject.cpp
+++ b/src/DspObject.cpp
@@ -71,8 +71,6 @@ DspObject::~DspObject() {
 #pragma mark -
 
 ConnectionType DspObject::getConnectionType(int outletIndex) {
-  if (outletIndex >= getNumDspOutlets())
-    return MESSAGE;
   return DSP;
 }
 

--- a/src/MessageSoundfiler.cpp
+++ b/src/MessageSoundfiler.cpp
@@ -2,7 +2,7 @@
  *  Copyright 2009,2010 Reality Jockey, Ltd.
  *                 info@rjdj.me
  *                 http://rjdj.me/
- * 
+ *
  *  This file is part of ZenGarden.
  *
  *  ZenGarden is free software: you can redistribute it and/or modify
@@ -14,16 +14,17 @@
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Lesser General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Lesser General Public License
  *  along with ZenGarden.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
-//#include <sndfile.h>
 #include "MessageSoundfiler.h"
 #include "MessageTable.h"
 #include "PdGraph.h"
+
+#include <sndfile.h>
 
 MessageObject *MessageSoundfiler::newObject(PdMessage *initMessage, PdGraph *graph) {
   return new MessageSoundfiler(initMessage, graph);
@@ -41,96 +42,108 @@ const char *MessageSoundfiler::getObjectLabel() {
   return "soundfiler";
 }
 
-void MessageSoundfiler::processMessage(int inletIndex, PdMessage *message) {
-/*
-  if (message->isSymbol(0, "read")) {
-    int currentElementIndex = 1;
+void MessageSoundfiler::processMessage(int inletIndex, PdMessage *message)
+{
+  if (message->isSymbol(0, "read"))
+  {
+    int currentElementIndex;
     bool shouldResizeTable = false;
+    char *tabName;
+    char *soundfilePath;
+    MessageTable *table;
     
-    while (currentElementIndex < message->getNumElements()) {
-      if (message->isSymbol(currentElementIndex)) {
-        // only the -resize flag is supported for now
-        if (message->isSymbol(currentElementIndex++, "-resize")) {
-          shouldResizeTable = true;
-        } else {
-          // all of the flags should have been seen now and now we expect the last two parameters,
-          // which are file location and destination table name
-          MessageElement *tableNameElement = message->getElement(currentElementIndex++);
-          if (messageElement != NULL && messageElement->isSymbol() &&
-              tableNameElement != NULL && tableNameElement->isSymbol()) {
-            MessageTable *table = graph->getTable(tableNameElement->getSymbol());
-            if (table != NULL) {
-              // use libsndfile to load and read the file (also converting the samples to [-1,1] float)
-              SF_INFO sfInfo;
-              char *fullPath = graph->resolveFullPath(messageElement->getSymbol());
-              if (fullPath == NULL) {
-                graph->printErr("[soundfiler]: file %s cannot be found.", messageElement->getSymbol());
-                return;
-              }
-              
-              SNDFILE *sndFile = sf_open(fullPath, SFM_READ, &sfInfo);
-              if (sndFile == NULL) {
-                graph->printErr("[soundfiler]: file %s cannot be opened.", fullPath);
-                free(fullPath);
-                return; // there was an error reading the file. Move on with life.
-              } 
-              free(fullPath);
-              
-              // It is assumed that the channels are interleaved.
-              int samplesPerChannel = sfInfo.frames;
-              int bufferLength = samplesPerChannel * sfInfo.channels;
-              // create a buffer in memory for the file data
-              float *buffer = (float *) malloc(bufferLength * sizeof(float));
-              sf_read_float(sndFile, buffer, bufferLength); // read the whole file into memory
-              sf_close(sndFile); // release the handle to the file
-              
-              if (sfInfo.channels > 0) { // sanity check
-                // get the table's buffer. Resize the buffer if necessary.
-                int tableLength = samplesPerChannel;
-                float *tableBuffer = shouldResizeTable ? table->resizeBuffer(samplesPerChannel) :
-                table->getBuffer(&tableLength);
-                if (tableLength > samplesPerChannel) {
-                  // avoid trying to read more into the table buffer than is available
-                  tableLength = samplesPerChannel;
-                }
-                
-                // extract the first channel
-                for (int i = 0, j = 0; i < bufferLength; i+=sfInfo.channels, j++) {
-                  tableBuffer[j] = buffer[i];
-                }
-                
-                // extract the second channel (if it exists and if there is a table to write it to)
-                if (sfInfo.channels > 1 &&
-                    (tableNameElement = message->getElement(currentElementIndex++)) != NULL &&
-                    tableNameElement->isSymbol() &&
-                    (table = graph->getTable(tableNameElement->getSymbol())) != NULL) {
-                  tableLength = samplesPerChannel;
-                  tableBuffer = shouldResizeTable ? table->resizeBuffer(samplesPerChannel) :
-                  table->getBuffer(&tableLength);
-                  if (tableLength > samplesPerChannel) {
-                    // avoid trying to read more into the table buffer than is available
-                    tableLength = samplesPerChannel;
-                  }
-                  for (int i = 1, j = 0; i < bufferLength; i+=sfInfo.channels, j++) {
-                    tableBuffer[j] = buffer[i];
-                  }
-                }
-              }
-              free(buffer);
-              
-              // send message with sample length when all tables have been filled
-              PdMessage *outgoingMessage = getNextOutgoingMessage(0);
-              outgoingMessage->setFloat(0, (float) samplesPerChannel);
-              outgoingMessage->setTimestamp(message->getTimestamp());
-              sendMessage(0, outgoingMessage);
-            }
-          }
+    for (currentElementIndex = 1;
+         currentElementIndex < message->getNumElements();
+         ++currentElementIndex)
+    {
+      if (message->isSymbol(currentElementIndex, "-resize"))
+        shouldResizeTable = true;
+      /* else if other flags... */
+      else
+        break;
+    }
+    if (message->getNumElements() - currentElementIndex - 2 < 0)
+    {
+      graph->printErr("[soundfiler]: parameters are incorrect");
+      return;
+    }
+    soundfilePath = message->getSymbol(currentElementIndex++);
+    tabName = message->getSymbol(currentElementIndex++);
+    if ((table = graph->getTable(tabName)) == NULL)
+    {
+      graph->printErr("[soundfiler]: table '%s' cannot be found", tabName);
+      return;
+    }
+    SF_INFO sfInfo;
+    char *fullPath = graph->resolveFullPath(soundfilePath);
+    if (fullPath == NULL)
+    {
+      graph->printErr("[soundfiler]: file '%s' cannot be found.", soundfilePath);
+      return;
+    }
+    
+    SNDFILE *sndFile = sf_open(fullPath, SFM_READ, &sfInfo);
+    if (sndFile == NULL)
+    {
+      graph->printErr("[soundfiler]: file %s cannot be opened.", fullPath);
+      free(fullPath);
+      return; // there was an error reading the file. Move on with life.
+    }
+    delete fullPath;
+    
+    // It is assumed that the channels are interleaved.
+    int samplesPerChannel = static_cast<int>(sfInfo.frames);
+    int bufferLength = samplesPerChannel * sfInfo.channels;
+    // create a buffer in memory for the file data
+    float *buffer = (float *) malloc(bufferLength * sizeof(float));
+    sf_read_float(sndFile, buffer, bufferLength); // read the whole file into memory
+    sf_close(sndFile); // release the handle to the file
+    
+    if (sfInfo.channels > 0) // sanity check
+    {
+      // get the table's buffer. Resize the buffer if necessary.
+      int tableLength = samplesPerChannel;
+      float *tableBuffer = shouldResizeTable ? table->resizeBuffer(samplesPerChannel) :
+      table->getBuffer(&tableLength);
+      if (tableLength > samplesPerChannel)
+      {
+        // avoid trying to read more into the table buffer than is available
+        tableLength = samplesPerChannel;
+      }
+      
+      // extract the first channel
+      for (int i = 0, j = 0; i < bufferLength; i+=sfInfo.channels, j++)
+      {
+        tableBuffer[j] = buffer[i];
+      }
+      
+      // extract the second channel (if it exists and if there is a table to write it to)
+      if (sfInfo.channels > 1 &&
+          (tabName = message->getSymbol(currentElementIndex++)) != NULL &&
+          (table = graph->getTable(tabName)) != NULL)
+      {
+        tableLength = samplesPerChannel;
+        tableBuffer = shouldResizeTable ? table->resizeBuffer(samplesPerChannel) :
+        table->getBuffer(&tableLength);
+        if (tableLength > samplesPerChannel)
+        {
+          // avoid trying to read more into the table buffer than is available
+          tableLength = samplesPerChannel;
         }
+        for (int i = 1, j = 0; i < bufferLength; i+=sfInfo.channels, j++)
+          tableBuffer[j] = buffer[i];
       }
     }
-  } else if (message->isSymbol(0, "write")) {
-    // TODO(mhroth): not supported yet
-    graph->printErr("The \"write\" command to soundfiler is not supported.");
+    delete buffer;
+    
+    // send message with sample length when all tables have been filled
+    PdMessage *outgoingMessage = PD_MESSAGE_ON_STACK(1);
+    outgoingMessage->initWithTimestampAndFloat(message->getTimestamp(), samplesPerChannel);
+    sendMessage(0, outgoingMessage);
   }
-*/
+  else if (message->isSymbol(0, "write"))
+  {
+    //Not implemented yet
+    graph->printErr("[soundfiler]: The 'write' command is not supported yet.");
+  }
 }

--- a/src/MessageSoundfiler.cpp
+++ b/src/MessageSoundfiler.cpp
@@ -147,3 +147,4 @@ void MessageSoundfiler::processMessage(int inletIndex, PdMessage *message)
     graph->printErr("[soundfiler]: The 'write' command is not supported yet.");
   }
 }
+

--- a/src/PdContext.cpp
+++ b/src/PdContext.cpp
@@ -206,7 +206,8 @@ void PdContext::attachGraph(PdGraph *graph) {
 
 void PdContext::unattachGraph(PdGraph *graph) {
   lock();
-  //graphList.erase(graph); // TODO(mhroth): remove the graph from the graphList
+  graphList.erase(std::remove(graphList.begin(), graphList.end(), graph),
+                  graphList.end());
   graph->attachToContext(false);
   unlock();
 }

--- a/src/PdContext.cpp
+++ b/src/PdContext.cpp
@@ -207,7 +207,7 @@ void PdContext::attachGraph(PdGraph *graph) {
 void PdContext::unattachGraph(PdGraph *graph) {
   lock();
   graphList.erase(std::remove(graphList.begin(), graphList.end(), graph),
-                  graphList.end());
+    graphList.end());
   graph->attachToContext(false);
   unlock();
 }

--- a/src/PdFileParser.cpp
+++ b/src/PdFileParser.cpp
@@ -64,6 +64,7 @@ PdFileParser::PdFileParser(string aString) {
     isDone = true;
   } else {
     stringDesc = aString;
+    pos = 0;
     nextLine(); // read the first line
     isDone = false;
   }

--- a/src/PdFileParser.cpp
+++ b/src/PdFileParser.cpp
@@ -64,7 +64,8 @@ PdFileParser::PdFileParser(string aString) {
     isDone = true;
   } else {
     stringDesc = aString;
-    nextLine(); // read the first line
+    pos = 0;
+	nextLine(); // read the first line
     isDone = false;
   }
 }

--- a/src/PdFileParser.cpp
+++ b/src/PdFileParser.cpp
@@ -64,8 +64,7 @@ PdFileParser::PdFileParser(string aString) {
     isDone = true;
   } else {
     stringDesc = aString;
-    pos = 0;
-	nextLine(); // read the first line
+    nextLine(); // read the first line
     isDone = false;
   }
 }

--- a/src/PdGraph.cpp
+++ b/src/PdGraph.cpp
@@ -364,7 +364,7 @@ string PdGraph::findFilePath(const char *filename) {
       return directory;
     }
   }
-  return isRootGraph() ? NULL : parentGraph->findFilePath(filename);
+  return isRootGraph() ? "" : parentGraph->findFilePath(filename);
 }
 
 void PdGraph::addDeclarePath(const char *path) {

--- a/src/ZenGarden.cpp
+++ b/src/ZenGarden.cpp
@@ -372,7 +372,7 @@ void zg_graph_attach(ZGGraph *graph) {
 }
 
 void zg_graph_unattach(ZGGraph *graph) {
-  graph->attachToContext(false);
+  graph->getContext()->unattachGraph(graph);
 }
 
 void zg_graph_add_connection(ZGGraph *graph, ZGObject *fromObject, int outletIndex, ZGObject *toObject, int inletIndex) {


### PR DESCRIPTION
Fixed zg_context_new_graph_from_string(ZGContext *, const char *) by fixing the constructor PdFileParser::PdFileParser(std::string) which was not initializing the 'pos' member, leading to the string being partially parsed or not parsed at all.

Fixed PdGraph::resolveFullPath(const char *) returning NULL when the graph as no parent whereas it should return a std::string

Fixed zg_graph_unattach(PdGraph *graph) directly calling PdGraph::attachToContext(bool) instead of calling PdContext::unattachGraph(PdGraph *). Also fixed PdContext::unattachGraph(PdGraph *) not removing the graph to its graph list.

Implemented MessageSoundfiler method, now it works but only support the read command

Fixed DspObject::getConnectionType(int) always returning DSP where it could be a MESSAGE outlet
