### PR TITLE
Fixed process order computing, lastArrayCreated is now reseted, fixed a build error

### DIFF
--- a/src/PdContext.cpp
+++ b/src/PdContext.cpp
@@ -206,6 +206,7 @@ void PdContext::attachGraph(PdGraph *graph) {
   lock();
   graphList.push_back(graph);
   graph->attachToContext(true);
+  graph->computeDeepLocalDspProcessOrder();
   unlock();
 }
 

--- a/src/PdFileParser.cpp
+++ b/src/PdFileParser.cpp
@@ -125,6 +125,7 @@ PdGraph *PdFileParser::execute(PdMessage *initMsg, PdGraph *graph, PdContext *co
   
   string message;
   MessageTable *lastArrayCreated = NULL;  // used to know on which table the #A line values have to be set
+  int lastArrayCreatedIndex = 0;
   while (!(message = nextMessage()).empty()) {
     // create a non-const copy of message such that strtok can modify it
     char line[message.size()+1];
@@ -284,6 +285,7 @@ PdGraph *PdFileParser::execute(PdMessage *initMsg, PdGraph *graph, PdContext *co
         initMessage->initWithSARb(4, objectInitString, graph->getArguments(), resBuffer, RESOLUTION_BUFFER_LENGTH);
         lastArrayCreated = reinterpret_cast<MessageTable *>(
           context->newObject("table", initMessage, graph));
+        lastArrayCreatedIndex = 0;
         graph->addObject(0, 0, lastArrayCreated);
         context->printStd("PdFileParser: Replacer array with table, name: '%s'", initMessage->getSymbol(0));
       } else if (!strcmp(objectType, "coords")) {
@@ -310,6 +312,11 @@ PdGraph *PdFileParser::execute(PdMessage *initMsg, PdGraph *graph, PdContext *co
           }
           buffer[index] = atof(token);
           ++index;
+          ++lastArrayCreatedIndex;
+        }
+        if (lastArrayCreatedIndex == bufferLength) {
+          lastArrayCreated = NULL;
+          lastArrayCreatedIndex = 0;
         }
       }
     } else {

--- a/src/PdFileParser.cpp
+++ b/src/PdFileParser.cpp
@@ -159,7 +159,7 @@ PdGraph *PdFileParser::execute(PdMessage *initMsg, PdGraph *graph, PdContext *co
             newGraph = new PdGraph(graph->getArguments(), graph, context, graph->getGraphId(), canvasName);
           } else {
             // a graph made as an abstraction
-            newGraph = new PdGraph(initMsg, graph, context, context->getNextGraphId(), rootPath+fileName);
+            newGraph = new PdGraph(initMsg, graph, context, context->getNextGraphId(), (rootPath+fileName).c_str());
             isSubPatch = true;
           }
           graph->addObject(0, 0, newGraph); // add the new graph to the current one as an object

--- a/src/PdGraph.cpp
+++ b/src/PdGraph.cpp
@@ -344,9 +344,6 @@ void PdGraph::attachToContext(bool isAttached) {
         pdGraph->attachToContext(isAttached);
       }
     }
-    // force dsp ordering as the last step
-    // some graphs may not have any connections (only abstractions), and thus may appear to do nothing
-    computeDeepLocalDspProcessOrder();
   }
 }
 


### PR DESCRIPTION
I moved the computeDeepLocalProcessOrder function call from PdGraph::attachToContext to PdContext::attachGraph. Indeed, the PdGraph::attachToContext is recursive, and the process order of some sub graphs was computed when some objects were not registered yet, leading to wrong process order for catch~ and throw~ objects. Now the process order is computed when all objects are registered.

lastArrayCreated variable in PdContext::execute is now reseted when all array values are read

I also fixed a build error in PdFileParser::execute
